### PR TITLE
Do not rely on the Activity object when this plugin is instantiated.

### DIFF
--- a/android/src/main/java/com/baseflow/googleapiavailability/GoogleApiAvailabilityPlugin.java
+++ b/android/src/main/java/com/baseflow/googleapiavailability/GoogleApiAvailabilityPlugin.java
@@ -1,6 +1,7 @@
 package com.baseflow.googleapiavailability;
 
 import android.app.Activity;
+import android.content.Context;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -47,13 +48,13 @@ public class GoogleApiAvailabilityPlugin implements MethodCallHandler {
 
   public static void registerWith(Registrar registrar) {
     final MethodChannel channel = new MethodChannel(registrar.messenger(), "flutter.baseflow.com/google_api_availability/methods");
-    channel.setMethodCallHandler(new GoogleApiAvailabilityPlugin(registrar.activity()));
+    channel.setMethodCallHandler(new GoogleApiAvailabilityPlugin(registrar.context()));
   }
 
-  private final Activity activity;
+  private final Context context;
 
-  private GoogleApiAvailabilityPlugin(Activity activity) {
-    this.activity = activity;
+  private GoogleApiAvailabilityPlugin(Context context) {
+    this.context = context;
   }
 
   @Override
@@ -61,10 +62,14 @@ public class GoogleApiAvailabilityPlugin implements MethodCallHandler {
     if (call.method.equals("checkPlayServicesAvailability")) {
       final Boolean showDialog = call.argument("showDialog");
       GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
-      final int connectionResult = googleApiAvailability.isGooglePlayServicesAvailable(activity);
+      final int connectionResult = googleApiAvailability.isGooglePlayServicesAvailable(context);
 
-      if (showDialog != null && showDialog) {
-        googleApiAvailability.showErrorDialogFragment(activity, connectionResult, REQUEST_GOOGLE_PLAY_SERVICES);
+
+      if (context instanceof Activity) {
+        Activity activity = (Activity) context;
+        if (showDialog != null && showDialog) {
+          googleApiAvailability.showErrorDialogFragment(activity, connectionResult, REQUEST_GOOGLE_PLAY_SERVICES);
+        }
       }
 
       final int availability = toPlayServiceAvailability(connectionResult);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Plugin is incompatible with background isolates which  may be held by a service on Android

### :new: What is the new behavior (if this is a feature change)?

Plugin will depend on the generic Context class and cast to activity (if available) to show the google play services warning fragment.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Setup a background isolate holder Service

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/BaseflowIT/flutter-geolocator/blob/develop/CONTRIBUTING.md))
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop