### PR TITLE
fix publish warnings

### DIFF
--- a/google_api_availability/CHANGELOG.md
+++ b/google_api_availability/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Updated example project Gradle build versions.
 * Updated Android package to version 1.1.0 (Flutter 3.29.0 support)
 * Removed codecov from workflow (ratelimits)
-* Fixed publishing warning'>=2.15.0 <3.0.0' to '>=2.15.0 <4.0.0'.
+* Fixed publishing warning and updated Dart SDK dependency from '>=2.15.0 <3.0.0' to '^3.5.0'.
 
 ## 5.0.0
 

--- a/google_api_availability/CHANGELOG.md
+++ b/google_api_availability/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Updated example project Gradle build versions.
 * Updated Android package to version 1.1.0 (Flutter 3.29.0 support)
 * Removed codecov from workflow (ratelimits)
+* Fixed publishing warning'>=2.15.0 <3.0.0' to '>=2.15.0 <4.0.0'.
 
 ## 5.0.0
 

--- a/google_api_availability/example/pubspec.yaml
+++ b/google_api_availability/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ^3.5.0
 
 dependencies:
   flutter:

--- a/google_api_availability/example/pubspec.yaml
+++ b/google_api_availability/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.15.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/google_api_availability/pubspec.yaml
+++ b/google_api_availability/pubspec.yaml
@@ -4,7 +4,7 @@ version: 5.0.1
 homepage: https://github.com/baseflowit/flutter-google-api-availability
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: ^3.5.0
   flutter: ">=2.8.1"
 
 dependencies:

--- a/google_api_availability/pubspec.yaml
+++ b/google_api_availability/pubspec.yaml
@@ -4,7 +4,7 @@ version: 5.0.1
 homepage: https://github.com/baseflowit/flutter-google-api-availability
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.15.0 <4.0.0'
   flutter: ">=2.8.1"
 
 dependencies:

--- a/google_api_availability_android/CHANGELOG.md
+++ b/google_api_availability_android/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  * Updates gradle version from 8.1.0 to 8.10.2
  * Updates android.application version from 8.1.0 to 8.7.0
+ * Fixed publishing warning'>=2.15.0 <3.0.0' to '>=2.15.0 <4.0.0'.
 
 ## 1.1.0
 

--- a/google_api_availability_android/CHANGELOG.md
+++ b/google_api_availability_android/CHANGELOG.md
@@ -2,7 +2,7 @@
 
  * Updates gradle version from 8.1.0 to 8.10.2
  * Updates android.application version from 8.1.0 to 8.7.0
- * Fixed publishing warning'>=2.15.0 <3.0.0' to '>=2.15.0 <4.0.0'.
+* Fixed publishing warning and updated Dart SDK dependency from '>=2.15.0 <3.0.0' to '^3.5.0'.
 
 ## 1.1.0
 

--- a/google_api_availability_android/example/pubspec.yaml
+++ b/google_api_availability_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ^3.5.0
 
 dependencies:
   flutter:

--- a/google_api_availability_android/example/pubspec.yaml
+++ b/google_api_availability_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0+1
 publish_to: none
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.15.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/google_api_availability_android/pubspec.yaml
+++ b/google_api_availability_android/pubspec.yaml
@@ -26,5 +26,5 @@ dev_dependencies:
   mockito: ^5.3.2
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ^3.5.0
   flutter: ">=2.8.0"

--- a/google_api_availability_android/pubspec.yaml
+++ b/google_api_availability_android/pubspec.yaml
@@ -26,5 +26,5 @@ dev_dependencies:
   mockito: ^5.3.2
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.15.0 <4.0.0"
   flutter: ">=2.8.0"

--- a/google_api_availability_platform_interface/CHANGELOG.md
+++ b/google_api_availability_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next
+
+* Fixed publishing warning'>=2.15.0 <3.0.0' to '>=2.15.0 <4.0.0'.
+
 ## 1.0.1
 
 * Adds `removeInstance` to `GoogleApiAvailabilityPlatform` for testing purposes.

--- a/google_api_availability_platform_interface/CHANGELOG.md
+++ b/google_api_availability_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## next
 
-* Fixed publishing warning'>=2.15.0 <3.0.0' to '>=2.15.0 <4.0.0'.
+* Fixed publishing warning and updated Dart SDK dependency from '>=2.15.0 <3.0.0' to '^3.5.0'.
 
 ## 1.0.1
 

--- a/google_api_availability_platform_interface/pubspec.yaml
+++ b/google_api_availability_platform_interface/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   mockito: ^5.3.2
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.15.0 <4.0.0"
   flutter: ">=2.8.0"

--- a/google_api_availability_platform_interface/pubspec.yaml
+++ b/google_api_availability_platform_interface/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   mockito: ^5.3.2
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ^3.5.0
   flutter: ">=2.8.0"


### PR DESCRIPTION
Fixed publish warning: `The declared SDK constraint is '>=2.15.0 <3.0.0', this is interpreted as '>=2.15.0 <4.0.0'.`

## Pre-launch Checklist

- [ ] I made sure the project builds.
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-google-api-availability/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
